### PR TITLE
New components and options strategy for FindMKL

### DIFF
--- a/FindMKL.cmake
+++ b/FindMKL.cmake
@@ -124,7 +124,7 @@ Note: Mixing GCC and Intel OpenMP backends is a bad idea.
 
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 
 # Modules
 #
@@ -153,11 +153,10 @@ find_package(OpenMP COMPONENTS CXX)
 # The `NOT DEFINED` guards on CACHED variables are needed to make sure that
 # normal variables of the same name always take precedence*.
 #
-# * There are many caveats with CACHE variables in CMake. Before version
-#   3.12, both `option()` and `set(... CACHE ...)` would override normal
-#   variables if cached equivalents don't exist or they exisit but their type
-#   is not specified (e.g. command line arguments: -DFOO=ON instead of
-#   -DFOO:BOOL=ON). For 3.13 with policy CMP0077, `option()` no longer overrides
+# * In v3.12, both `option()` and `set(... CACHE ...)` override normal
+#   variables if a) cached equivalents don't exist or b) their type is not 
+#   specified (e.g. command line arguments: -DFOO=ON instead of
+#   -DFOO:BOOL=ON). Since v3.13 with policy CMP0077, `option()` no longer overrides
 #   normal variables of the same name. `set(... CACHE ...)` is still stuck with
 #   the old behaviour.
 #

--- a/FindMKL.cmake
+++ b/FindMKL.cmake
@@ -136,6 +136,7 @@ function(__mkl_find_library _name)
     find_library(${_name}
         NAMES ${ARGN}
         HINTS ${MKL_ROOT}
+              ${MKL_ROOT}/mkl
         PATH_SUFFIXES ${_mkl_libpath_suffix}
                       lib
         )
@@ -186,6 +187,7 @@ endif()
 #
 find_path(MKL_INCLUDE_DIR mkl.h
     HINTS ${MKL_ROOT}/include
+          ${MKL_ROOT}/mkl/include
     )
 mark_as_advanced(MKL_INCLUDE_DIR)
 

--- a/FindMKL.cmake
+++ b/FindMKL.cmake
@@ -65,7 +65,7 @@ Note: dependencies are handled for you (MPI, OpenMP, ...)
 Imported targets
 ^^^^^^^^^^^^^^^^
 
-MKL (BLAS, LAPACK, FFT) tarets:
+MKL (BLAS, LAPACK, FFT) targets:
 
   mkl::mkl_[gf|intel]_[32bit|64bit]_[seq|omp|tbb]_[st|dyn] e.g.
 
@@ -97,14 +97,13 @@ Not supported
 
 cmake_minimum_required(VERSION 3.12)
 
-# Modules
-#
-include(FindPackageHandleStandardArgs)
-
-if(NOT (CMAKE_C_COMPILER_LOADED OR
-        CMAKE_CXX_COMPILER_LOADED OR
-        CMAKE_Fortran_COMPILER_LOADED))
-    message(FATAL_ERROR "FindMKL requires Fortran, C, or C++ to be enabled.")
+# check if compatible compiler is found
+if(CMAKE_C_COMPILER_LOADED OR
+   CMAKE_CXX_COMPILER_LOADED OR
+   CMAKE_Fortran_COMPILER_LOADED)
+    set(_mkl_compiler_found TRUE)
+else()
+    set(_mkl_compiler_found FALSE)
 endif()
 
 # Dependencies
@@ -116,7 +115,7 @@ find_package(OpenMP COMPONENTS CXX)
 # If MKL_ROOT is not set, set it via the env variable MKLROOT.
 #
 if(NOT DEFINED MKL_ROOT)
-    set(MKL_ROOT $ENV{MKLROOT} CACHE PATH "MKL's root directory.")
+    set(MKL_ROOT $ENV{MKLROOT})
 endif()
 
 # Determine MKL's library folder
@@ -143,9 +142,8 @@ else() # LINUX
     set(_mkl_static_lib ".a")
 endif()
 set(_mkl_search_paths "${MKL_ROOT}"
-                      "${MKL_ROOT}/lib"
-                      "${MKL_ROOT}/mkl/lib"
-                      "${MKL_ROOT}/compiler/lib")
+                      "${MKL_ROOT}/mkl"
+                      "${MKL_ROOT}/compiler")
 
 # Functions: finds both static and shared MKL libraries
 #
@@ -221,11 +219,13 @@ __mkl_find_library(MKL_SCALAPACK_64BIT_LIB mkl_scalapack_ilp64)
 
 # Check if core libs were found
 #
+include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(MKL REQUIRED_VARS MKL_INCLUDE_DIR
-                                                    Threads_FOUND)
+                                                    Threads_FOUND
+                                                    _mkl_compiler_found)
 
 # Sequential has no threading dependency. There is currently no TBB module 
-# shipped with CMake. The dependency is not accounted for. (FIXME)
+# shipped with CMake. The dependency is not accounted for.
 #
 set(_mkl_dep_found_SEQ TRUE)
 set(_mkl_dep_found_TBB TRUE)

--- a/FindMKL.cmake
+++ b/FindMKL.cmake
@@ -13,6 +13,8 @@ FindMKL
 
 The following conventions are used:
 
+intel / INTEL  - Bindings for everything except GNU Fortran
+gf / GF        - GNU Fortran bindings
 seq / SEQ      - sequential MKL
 omp / OMP      - threaded MKL with OpenMP back end
 tbb / TBB      - threaded MKL with TBB back end
@@ -20,10 +22,17 @@ tbb / TBB      - threaded MKL with TBB back end
 64bit / 64BIT  - MKL 64 bit integer interface
 mpich / MPICH  - MPICH / IntelMPI BLACS back end
 ompi / OMPI    - OpenMPI BLACS back end
+st / ST        - static libraries
+dyn / DYN      - dynamic libraries
 
 The module attempts to define a target for each MKL configuration. The
 configuration will not be available if there are missing library files or a
 missing dependency.
+
+MKL Link line advisor:
+  https://software.intel.com/en-us/articles/intel-mkl-link-line-advisor
+
+Note: Mixing GCC and Intel OpenMP backends is a bad idea.
 
 Search variables
 ^^^^^^^^^^^^^^^^
@@ -43,53 +52,36 @@ To Find MKL:
 
 To check if target is available:
 
-  if (TARGET mkl::scalapack_mpich_32bit_seq)
+  if (TARGET mkl::scalapack_mpich_intel_32bit_omp_dyn)
     ...
   endif()
 
 To link to an available target (see list below):
 
-  target_link_libraries(... mkl::scalapack_mpich_32bit_omp)
+  target_link_libraries(... mkl::scalapack_mpich_intel_32bit_omp_dyn)
 
 Note: dependencies are handled for you (MPI, OpenMP, ...)
 
 Imported targets
 ^^^^^^^^^^^^^^^^
 
-mkl::core
+MKL (BLAS, LAPACK, FFT) tarets:
 
-mkl::blas_32bit_seq
-mkl::blas_32bit_omp
-mkl::blas_32bit_tbb
-mkl::blas_64bit_seq
-mkl::blas_64bit_omp
-mkl::blas_64bit_tbb
+  mkl::mkl_[gf|intel]_[32bit|64bit]_[seq|omp|tbb]_[st|dyn] e.g.
 
-mkl::blacs_mpich_32bit_seq
-mkl::blacs_mpich_32bit_omp
-mkl::blacs_mpich_32bit_tbb
-mkl::blacs_mpich_64bit_seq
-mkl::blacs_mpich_64bit_omp
-mkl::blacs_mpich_64bit_tbb
-mkl::blacs_ompi_32bit_seq
-mkl::blacs_ompi_32bit_omp
-mkl::blacs_ompi_32bit_tbb
-mkl::blacs_ompi_64bit_seq
-mkl::blacs_ompi_64bit_omp
-mkl::blacs_ompi_64bit_tbb
+  mkl::mkl_intel_32bit_omp_dyn
 
-mkl::scalapack_mpich_32bit_seq
-mkl::scalapack_mpich_32bit_omp
-mkl::scalapack_mpich_32bit_tbb
-mkl::scalapack_mpich_64bit_seq
-mkl::scalapack_mpich_64bit_omp
-mkl::scalapack_mpich_64bit_tbb
-mkl::scalapack_ompi_32bit_seq
-mkl::scalapack_ompi_32bit_omp
-mkl::scalapack_ompi_32bit_tbb
-mkl::scalapack_ompi_64bit_seq
-mkl::scalapack_ompi_64bit_omp
-mkl::scalapack_ompi_64bit_tbb
+BLACS targets:
+
+  mkl::blacs_[mpich|ompi]_[gf|intel]_[32bit|64bit]_[seq|omp|tbb]_[st|dyn] e.g.
+
+  mkl::blacs_intel_mpich_32bit_seq_st
+
+ScaLAPACK targets:
+
+  mkl::scalapack_[mpich|ompi]_[gf|intel]_[32bit|64bit]_[seq|omp|tbb]_[st|dyn] e.g.
+
+  mkl::scalapack_intel_mpich_64bit_omp_dyn
 
 Result variables
 ^^^^^^^^^^^^^^^^
@@ -101,8 +93,6 @@ Not supported
 
 - F95 interfaces
 
-Note: Mixing GCC and Intel OpenMP backends is a bad idea.
-
 #]=======================================================================]
 
 cmake_minimum_required(VERSION 3.12)
@@ -111,18 +101,11 @@ cmake_minimum_required(VERSION 3.12)
 #
 include(FindPackageHandleStandardArgs)
 
-# Functions
-#
-function(__mkl_find_library _name)
-    find_library(${_name}
-        NAMES ${ARGN}
-        HINTS ${MKL_ROOT}
-              ${MKL_ROOT}/mkl
-        PATH_SUFFIXES ${_mkl_libpath_suffix}
-                      lib
-        )
-    mark_as_advanced(${_name})
-endfunction()
+if(NOT (CMAKE_C_COMPILER_LOADED OR
+        CMAKE_CXX_COMPILER_LOADED OR
+        CMAKE_Fortran_COMPILER_LOADED))
+    message(FATAL_ERROR "FindMKL requires Fortran, C, or C++ to be enabled.")
+endif()
 
 # Dependencies
 #
@@ -130,20 +113,7 @@ find_package(Threads)
 find_package(MPI COMPONENTS CXX)
 find_package(OpenMP COMPONENTS CXX)
 
-# Options
-#
-# The `NOT DEFINED` guards on CACHED variables are needed to make sure that
-# normal variables of the same name always take precedence*.
-#
-# * In v3.12, both `option()` and `set(... CACHE ...)` override normal
-#   variables if a) cached equivalents don't exist or b) their type is not 
-#   specified (e.g. command line arguments: -DFOO=ON instead of
-#   -DFOO:BOOL=ON). Since v3.13 with policy CMP0077, `option()` no longer overrides
-#   normal variables of the same name. `set(... CACHE ...)` is still stuck with
-#   the old behaviour.
-#
-#   https://cmake.org/cmake/help/v3.15/command/set.html#set-cache-entry
-#   https://cmake.org/cmake/help/v3.15/policy/CMP0077.html
+# If MKL_ROOT is not set, set it via the env variable MKLROOT.
 #
 if(NOT DEFINED MKL_ROOT)
     set(MKL_ROOT $ENV{MKLROOT} CACHE PATH "MKL's root directory.")
@@ -158,31 +128,74 @@ endif()
 
 if(WIN32)
     string(APPEND _mkl_libpath_suffix "_win")
+    set(_mkl_libname_prefix "")
+    set(_mkl_shared_lib "_dll.lib")
+    set(_mkl_static_lib ".lib")
 elseif(APPLE)
     string(APPEND _mkl_libpath_suffix "_mac")
-else()
+    set(_mkl_libname_prefix "lib")
+    set(_mkl_shared_lib ".dylib")
+    set(_mkl_static_lib ".a")
+else() # LINUX
     string(APPEND _mkl_libpath_suffix "_lin")
+    set(_mkl_libname_prefix "lib")
+    set(_mkl_shared_lib ".so")
+    set(_mkl_static_lib ".a")
 endif()
+set(_mkl_search_paths "${MKL_ROOT}"
+                      "${MKL_ROOT}/lib"
+                      "${MKL_ROOT}/mkl/lib"
+                      "${MKL_ROOT}/compiler/lib")
 
-# Find MKL header
+# Functions: finds both static and shared MKL libraries
+#
+function(__mkl_find_library _varname _libname)
+    find_library(${_varname}_DYN
+          NAMES ${_mkl_libname_prefix}${_libname}${_mkl_shared_lib}
+          HINTS ${_mkl_search_paths}
+          PATH_SUFFIXES ${_mkl_libpath_suffix})
+    mark_as_advanced(${_varname}_DYN)
+    find_library(${_varname}_ST
+          NAMES ${_mkl_libname_prefix}${_libname}${_mkl_static_lib}
+          HINTS ${_mkl_search_paths}
+          PATH_SUFFIXES ${_mkl_libpath_suffix})
+    mark_as_advanced(${_varname}_ST)
+endfunction()
+
+# Find MKL headers
 #
 find_path(MKL_INCLUDE_DIR mkl.h
     HINTS ${MKL_ROOT}/include
-          ${MKL_ROOT}/mkl/include
-    )
+          ${MKL_ROOT}/mkl/include)
 mark_as_advanced(MKL_INCLUDE_DIR)
+
+# Group flags for static libraries on Linux (GNU, PGI, ICC -> same linker)
+#
+if(UNIX AND NOT APPLE)
+    set(_mkl_linker_pre_flags_ST "-Wl,--start-group")
+    set(_mkl_linker_post_flags_ST "-Wl,--end-group")
+endif()
 
 # Core MKL
 #
 __mkl_find_library(MKL_CORE_LIB mkl_core)
 
-# BLAS
+# Interface
 #
-__mkl_find_library(MKL_INTERFACE_32BIT_LIB mkl_intel_lp64)
-__mkl_find_library(MKL_INTERFACE_64BIT_LIB mkl_intel_ilp64)
+__mkl_find_library(MKL_INTERFACE_INTEL_32BIT_LIB mkl_intel_lp64)
+__mkl_find_library(MKL_INTERFACE_INTEL_64BIT_LIB mkl_intel_ilp64)
+if(NOT APPLE AND CMAKE_Fortran_COMPILER_LOADED
+             AND CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+    __mkl_find_library(MKL_INTERFACE_GF_32BIT_LIB mkl_gf_lp64)
+    __mkl_find_library(MKL_INTERFACE_GF_64BIT_LIB mkl_gf_ilp64)
+endif()
 
+# Threading
+#
 __mkl_find_library(MKL_SEQ_LIB mkl_sequential)
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT APPLE)
+if(NOT APPLE AND (CMAKE_C_COMPILER_ID STREQUAL "GNU" OR
+                  CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
+                  CMAKE_Fortran_COMPILER_ID STREQUAL "GNU"))
     __mkl_find_library(MKL_OMP_LIB mkl_gnu_thread)
 else()
     __mkl_find_library(MKL_OMP_LIB mkl_intel_thread)
@@ -209,69 +222,88 @@ __mkl_find_library(MKL_SCALAPACK_64BIT_LIB mkl_scalapack_ilp64)
 # Check if core libs were found
 #
 find_package_handle_standard_args(MKL REQUIRED_VARS MKL_INCLUDE_DIR
-                                                    MKL_CORE_LIB
                                                     Threads_FOUND)
 
-if (MKL_FOUND AND NOT TARGET mkl::core)
-    add_library(mkl::core INTERFACE IMPORTED)
-    set_target_properties(mkl::core PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES "${MKL_INCLUDE_DIR}"
-        INTERFACE_LINK_LIBRARIES "${MKL_CORE_LIB}")
+# Sequential has no threading dependency. There is currently no TBB module 
+# shipped with CMake. The dependency is not accounted for. (FIXME)
+#
+set(_mkl_dep_found_SEQ TRUE)
+set(_mkl_dep_found_TBB TRUE)
+if (TARGET OpenMP::OpenMP_CXX)
+  set(_mkl_dep_OMP OpenMP::OpenMP_CXX)
+  set(_mkl_dep_found_OMP TRUE)
 endif()
 
 # Define all blas, blacs and scalapack
 #
-foreach(_bits "32BIT" "64BIT")
-    set(_mkl_interface_lib ${MKL_INTERFACE_${_bits}_LIB})
-    set(_mkl_scalapack_lib ${MKL_SCALAPACK_${_bits}_LIB})
+foreach(_libtype "ST" "DYN")
+    set(_mkl_core_lib ${MKL_CORE_LIB_${_libtype}})
+    foreach(_bits "32BIT" "64BIT")
+        set(_mkl_scalapack_lib ${MKL_SCALAPACK_${_bits}_LIB_${_libtype}})
+        foreach(_iface "INTEL" "GF")
+            set(_mkl_interface_lib ${MKL_INTERFACE_${_iface}_${_bits}_LIB_${_libtype}})
+            foreach(_threading "SEQ" "OMP" "TBB")
+                set(_mkl_threading_lib ${MKL_${_threading}_LIB_${_libtype}})
 
-    foreach(_threading "SEQ" "OMP" "TBB")
-        string(TOLOWER "${_bits}_${_threading}" _tgt_config)
-        set(_blas_tgt mkl::blas_${_tgt_config})
-        set(_mkl_threading_lib ${MKL_${_threading}_LIB})
+                string(TOLOWER "${_iface}_${_bits}_${_threading}_${_libtype}" _tgt_config)
+                set(_mkl_tgt mkl::mkl_${_tgt_config})
 
-        set(_mkl_threading_deps "Threads::Threads")
-        if(${_threading} STREQUAL "OMP" )
-            if(TARGET OpenMP::OpenMP_CXX)
-                set(_mkl_deps "OpenMP::OpenMP_CXX;Threads::Threads")
-            else()
-                continue() # skip all OMP targets
-            endif()
-        endif()
+                if(MKL_FOUND
+                   AND _mkl_interface_lib
+                   AND _mkl_threading_lib
+                   AND _mkl_core_lib
+                   AND _mkl_dep_found_${_threading}
+                   AND NOT TARGET ${_mkl_tgt})
+                    set(_mkl_libs "${_mkl_linker_pre_flags_${_threading}}"
+                                  "${_mkl_interface_lib}"
+                                  "${_mkl_threading_lib}"
+                                  "${_mkl_core_lib}"
+                                  "${_mkl_linker_post_flags_${_threading}}"
+                                  "${_mkl_dep_${_threading}}"
+                                  "Threads::Threads")
+                    add_library(${_mkl_tgt} INTERFACE IMPORTED)
+                    set_target_properties(${_mkl_tgt} PROPERTIES
+                      INTERFACE_INCLUDE_DIRECTORIES "${MKL_INCLUDE_DIR}"
+                      INTERFACE_LINK_LIBRARIES "${_mkl_libs}")
+                endif()
 
-        set(_mkl_prefix_libs "${_mkl_interface_lib};${_mkl_threading_lib};mkl::core")
-        if(MKL_FOUND
-           AND _mkl_interface_lib
-           AND _mkl_threading_lib
-           AND NOT TARGET ${_blas_tgt})
-            add_library(${_blas_tgt} INTERFACE IMPORTED)
-            set_target_properties(${_blas_tgt} PROPERTIES
-              INTERFACE_LINK_LIBRARIES "${_mkl_prefix_libs};${_mkl_threading_deps}")
-        endif()
+                foreach(_mpi_impl "MPICH" "OMPI")
+                    set(_mkl_blacs_lib ${MKL_BLACS_${_mpi_impl}_${_bits}_LIB_${_libtype}})
 
-        foreach(_mpi_impl "MPICH" "OMPI")
-            string(TOLOWER "${_mpi_impl}_${_bits}_${_threading}" _tgt_config)
-            set(_blacs_tgt mkl::blacs_${_tgt_config})
-            set(_scalapack_tgt mkl::scalapack_${_tgt_config})
-            set(_mkl_blacs_lib ${MKL_BLACS_${_mpi_impl}_${_bits}_LIB})
+                    string(TOLOWER "${_mpi_impl}_${_iface}_${_bits}_${_threading}_${_libtype}" _tgt_config)
+                    set(_blacs_tgt mkl::blacs_${_tgt_config})
+                    set(_scalapack_tgt mkl::scalapack_${_tgt_config})
 
-            if(_mkl_blacs_lib
-               AND TARGET MPI::MPI_CXX
-               AND TARGET ${_blas_tgt}
-               AND NOT TARGET ${_blacs_tgt})
-                add_library(${_blacs_tgt} INTERFACE IMPORTED)
-                set_target_properties(${_blacs_tgt} PROPERTIES
-                    INTERFACE_LINK_LIBRARIES "${_mkl_prefix_libs};${_mkl_blacs_lib};${_mkl_threading_deps};MPI::MPI_CXX")
-            endif()
+                    if(_mkl_blacs_lib
+                       AND TARGET ${_mkl_tgt}
+                       AND TARGET MPI::MPI_CXX
+                       AND NOT TARGET ${_blacs_tgt})
+                        set(_blacs_libs "${_mkl_linker_pre_flags_${_libtype}}"
+                                        "${_mkl_interface_lib}"
+                                        "${_mkl_threading_lib}"
+                                        "${_mkl_core_lib}"
+                                        "${_mkl_blacs_lib}"
+                                        "${_mkl_linker_post_flags_${_libtype}}"
+                                        "MPI::MPI_CXX"
+                                        "${_mkl_dep_${_threading}}"
+                                        "Threads::Threads")
+                        add_library(${_blacs_tgt} INTERFACE IMPORTED)
+                        set_target_properties(${_blacs_tgt} PROPERTIES
+                            INTERFACE_INCLUDE_DIRECTORIES "${MKL_INCLUDE_DIR}"
+                            INTERFACE_LINK_LIBRARIES "${_blacs_libs}")
+                    endif()
 
-            if(_mkl_scalapack_lib
-               AND TARGET ${_blacs_tgt}
-               AND NOT TARGET ${_scalapack_tgt})
-                add_library(${_scalapack_tgt} INTERFACE IMPORTED)
-                set_target_properties(${_scalapack_tgt} PROPERTIES
-                    INTERFACE_LINK_LIBRARIES "${_mkl_scalapack_lib};${_blacs_tgt}")
-            endif()
-      endforeach()
+                    if(_mkl_scalapack_lib
+                       AND TARGET ${_blacs_tgt}
+                       AND NOT TARGET ${_scalapack_tgt})
+                        set(_scalapack_libs "${_mkl_scalapack_lib}"
+                                            "${_blacs_tgt}")
+                        add_library(${_scalapack_tgt} INTERFACE IMPORTED)
+                        set_target_properties(${_scalapack_tgt} PROPERTIES
+                            INTERFACE_LINK_LIBRARIES "${_scalapack_libs}")
+                    endif()
+                endforeach()
+            endforeach()
+        endforeach()
     endforeach()
 endforeach()
-


### PR DESCRIPTION
- Remove options `MKL_PARALLEL` and `MKL_64BIT` as all target combinations are automatically searched for and made available. Moreover, In the previous implementation the variables had no influence on subsequent `find_library` calls even if toggled from the cache. `find_library` produces CACHE variables which are not updated once the library is found.

- Instantiate all MKL combinations (sequential, OpenMP, 32bit, 64bit) as targets and components. These are searched for by default and made available if found. The script provides appropriate messages if a component is explicitly required: `find_package(MKL REQUIRED blas_32bit_seq)` in case it's found/not found. It also handles component dependencies appropriately.

  This simplifies the usage of the module considerably as in most cases users just need to do `find_package(MKL)` and link with the target that they prefer.

  Opting out of searching for certain combinations doesn't save much script processing time but somewhat complicates the implementation. Therefor all components are searched for.

- The minimum CMake version is set to 3.10.

- Tested in COSMA with:
  `find_package(MKL REQUIRED COMPONENTS BLAS_32BIT_OMP)`
  `find_package(MKL REQUIRED COMPONENTS SCALAPACK_32BIT_OMP)`