### PR TITLE
fix mkl detection on mac

### DIFF
--- a/FindMKL.cmake
+++ b/FindMKL.cmake
@@ -124,7 +124,6 @@ set(_mkl_libpath_suffix "lib/intel64")
 if(CMAKE_SIZEOF_VOID_P EQUAL 4) # 32 bit
     set(_mkl_libpath_suffix "lib/ia32")
 endif()
-list(APPEND _mkl_libpath_suffix "lib")
 
 if(WIN32)
     string(APPEND _mkl_libpath_suffix "_win")
@@ -132,6 +131,7 @@ if(WIN32)
     set(_mkl_shared_lib "_dll.lib")
     set(_mkl_static_lib ".lib")
 elseif(APPLE)
+    string(APPEND _mkl_libpath_suffix "_mac")
     set(_mkl_libname_prefix "lib")
     set(_mkl_shared_lib ".dylib")
     set(_mkl_static_lib ".a")
@@ -141,18 +141,22 @@ else() # LINUX
     set(_mkl_shared_lib ".so")
     set(_mkl_static_lib ".a")
 endif()
+set(_mkl_search_paths "${MKL_ROOT}"
+                      "${MKL_ROOT}/lib"
+                      "${MKL_ROOT}/mkl"
+                      "${MKL_ROOT}/compiler")
 
 # Functions: finds both static and shared MKL libraries
 #
 function(__mkl_find_library _varname _libname)
     find_library(${_varname}_DYN
           NAMES ${_mkl_libname_prefix}${_libname}${_mkl_shared_lib}
-          HINTS ${MKL_ROOT}
+          HINTS ${_mkl_search_paths}
           PATH_SUFFIXES ${_mkl_libpath_suffix})
     mark_as_advanced(${_varname}_DYN)
     find_library(${_varname}_ST
           NAMES ${_mkl_libname_prefix}${_libname}${_mkl_static_lib}
-          HINTS ${MKL_ROOT}
+          HINTS ${_mkl_search_paths}
           PATH_SUFFIXES ${_mkl_libpath_suffix})
     mark_as_advanced(${_varname}_ST)
 endfunction()

--- a/FindMKL.cmake
+++ b/FindMKL.cmake
@@ -132,7 +132,6 @@ if(WIN32)
     set(_mkl_shared_lib "_dll.lib")
     set(_mkl_static_lib ".lib")
 elseif(APPLE)
-    string(APPEND _mkl_libpath_suffix "_mac")
     set(_mkl_libname_prefix "lib")
     set(_mkl_shared_lib ".dylib")
     set(_mkl_static_lib ".a")
@@ -142,21 +141,18 @@ else() # LINUX
     set(_mkl_shared_lib ".so")
     set(_mkl_static_lib ".a")
 endif()
-set(_mkl_search_paths "${MKL_ROOT}"
-                      "${MKL_ROOT}/mkl"
-                      "${MKL_ROOT}/compiler")
 
 # Functions: finds both static and shared MKL libraries
 #
 function(__mkl_find_library _varname _libname)
     find_library(${_varname}_DYN
           NAMES ${_mkl_libname_prefix}${_libname}${_mkl_shared_lib}
-          HINTS ${_mkl_search_paths}
+          HINTS ${MKL_ROOT}
           PATH_SUFFIXES ${_mkl_libpath_suffix})
     mark_as_advanced(${_varname}_DYN)
     find_library(${_varname}_ST
           NAMES ${_mkl_libname_prefix}${_libname}${_mkl_static_lib}
-          HINTS ${_mkl_search_paths}
+          HINTS ${MKL_ROOT}
           PATH_SUFFIXES ${_mkl_libpath_suffix})
     mark_as_advanced(${_varname}_ST)
 endfunction()
@@ -225,7 +221,7 @@ find_package_handle_standard_args(MKL REQUIRED_VARS MKL_INCLUDE_DIR
                                                     Threads_FOUND
                                                     _mkl_compiler_found)
 
-# Sequential has no threading dependency. There is currently no TBB module 
+# Sequential has no threading dependency. There is currently no TBB module
 # shipped with CMake. The dependency is not accounted for.
 #
 set(_mkl_dep_found_SEQ TRUE)


### PR DESCRIPTION
The main difference between linux and mac seems to be this

Linux
```
/opt/intel/compilers_and_libraries_2020.1.217/linux/mkl/lib
|-- ia32 -> ./ia32_lin
|-- ia32_lin
|-- intel64 -> ./intel64_lin
`-- intel64_lin
```

Mac
```
tree -L 1 $MKLROOT/lib
/opt/intel/compilers_and_libraries_2019.1.144/mac/mkl/lib
├── libmkl_avx.dylib
├── libmkl_avx2.dylib
├── libmkl_avx512.dylib
...
```