### PR TITLE
fix: do not append "_lin" to lib suffix on Linux

### DIFF
--- a/FindMKL.cmake
+++ b/FindMKL.cmake
@@ -136,7 +136,6 @@ elseif(APPLE)
     set(_mkl_shared_lib ".dylib")
     set(_mkl_static_lib ".a")
 else() # LINUX
-    string(APPEND _mkl_libpath_suffix "_lin")
     set(_mkl_libname_prefix "lib")
     set(_mkl_shared_lib ".so")
     set(_mkl_static_lib ".a")


### PR DESCRIPTION
I recently installed the latest version of MKL on a Linux system, and noticed that `lib/intel64_lin` does not exist. Spawning errors at configuration time with CMake (targets not being found).

PS: I noticed that the Windows distribution of MKL also has folder ~~`lib/intel64`.
`lib/intel64_win` is just a symlink to it.~~ The folder is `lib/intel64_win` and `lib/intel64` is a symlink to it.
It should be possible to remove the same line for the Windows case.