### PR TITLE
Fix FindMKL search path problem

### DIFF
--- a/FindMKL.cmake
+++ b/FindMKL.cmake
@@ -120,23 +120,30 @@ endif()
 
 # Determine MKL's library folder
 #
+
+# Note:
+# _mkl_libpath_suffix has to enter the platform selection either:
+#   - as a string or
+#   - as a single-element list
+# because then the following platform customization adds a second element with the "_<os>" suffix
+
 set(_mkl_libpath_suffix "lib/intel64")
 if(CMAKE_SIZEOF_VOID_P EQUAL 4) # 32 bit
     set(_mkl_libpath_suffix "lib/ia32")
 endif()
 
 if(WIN32)
-    string(APPEND _mkl_libpath_suffix "_win")
+    list(APPEND _mkl_libpath_suffix "${_mkl_libpath_suffix}_win")
     set(_mkl_libname_prefix "")
     set(_mkl_shared_lib "_dll.lib")
     set(_mkl_static_lib ".lib")
 elseif(APPLE)
-    string(APPEND _mkl_libpath_suffix "_mac")
+    list(APPEND _mkl_libpath_suffix "${_mkl_libpath_suffix}_mac")
     set(_mkl_libname_prefix "lib")
     set(_mkl_shared_lib ".dylib")
     set(_mkl_static_lib ".a")
 else() # LINUX
-    string(APPEND _mkl_libpath_suffix "_lin")
+    list(APPEND _mkl_libpath_suffix "${_mkl_libpath_suffix}_lin")
     set(_mkl_libname_prefix "lib")
     set(_mkl_shared_lib ".so")
     set(_mkl_static_lib ".a")

--- a/FindMKL.cmake
+++ b/FindMKL.cmake
@@ -120,13 +120,6 @@ endif()
 
 # Determine MKL's library folder
 #
-
-# Note:
-# _mkl_libpath_suffix has to enter the platform selection either:
-#   - as a string or
-#   - as a single-element list
-# because then the following platform customization adds a second element with the "_<os>" suffix
-
 set(_mkl_libpath_suffix "lib/intel64")
 if(CMAKE_SIZEOF_VOID_P EQUAL 4) # 32 bit
     set(_mkl_libpath_suffix "lib/ia32")


### PR DESCRIPTION
Close #13

This workaround should fix the problem reported in #13, following what it was noted in https://github.com/eth-cscs/cmake-recipes/pull/12#issuecomment-786520061

The idea is to keep all the possible search paths.

In particular, the fix uses as search paths both
- `lib/intel64` (wo/OS suffix)
- `lib/intel64_lin` (w/OS suffix)